### PR TITLE
Fix IF node syntax in workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,6 +279,7 @@ This list is more of a "registry" than a task assignment.
 - [ ] All external calls are protected by timeouts and checkpoints.
 - [ ] Event logs at key steps, correlation by key.
 - [ ] Exported `.json` passes `n8n/scripts/validate-flows.mjs`.
+- [ ] `If` nodes use version ≥2 syntax (`typeVersion` 2.2) with `conditions.conditions[]`, `operator.type`, and `combinator` (`and`/`or`).
 
 **Before merge:**
 

--- a/n8n/flows/crm.in.forms.json
+++ b/n8n/flows/crm.in.forms.json
@@ -20,17 +20,22 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $('1e. Validate & Shape').item.json.classification.label }}",
-              "value2": "spam"
+              "leftValue": "={{ $('1e. Validate & Shape').item.json.classification.label }}",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              },
+              "rightValue": "spam"
             }
           ]
         }
       },
       "name": "4. Is Spam?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -6464,
         176
@@ -219,17 +224,22 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $('1e. Validate & Shape').item.json.company_name }}",
-              "operation": "isNotEmpty"
+              "leftValue": "={{ $('1e. Validate & Shape').item.json.company_name }}",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              },
+              "rightValue": null
             }
           ]
         }
       },
       "name": "IF: Company Name Exists?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -6192,
         240
@@ -262,17 +272,22 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $('1e. Validate & Shape').item.json.company_website }}",
-              "operation": "isNotEmpty"
+              "leftValue": "={{ $('1e. Validate & Shape').item.json.company_website }}",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              },
+              "rightValue": null
             }
           ]
         }
       },
       "name": "IF: Website Exists?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -5872,
         96
@@ -347,17 +362,22 @@
     {
       "parameters": {
         "conditions": {
-          "number": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $('1. Find Contact by Email').item.json.contact_id }}",
-              "operation": "isNotEmpty"
+              "leftValue": "={{ $('1. Find Contact by Email').item.json.contact_id }}",
+              "operator": {
+                "type": "number",
+                "operation": "notEmpty"
+              },
+              "rightValue": null
             }
           ]
         }
       },
       "name": "2. IF: Contact Found?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -4752,
         336
@@ -612,17 +632,22 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $('1e. Validate & Shape').item.json.lead_intent }}",
-              "value2": "client"
+              "leftValue": "={{ $('1e. Validate & Shape').item.json.lead_intent }}",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              },
+              "rightValue": "client"
             }
           ]
         }
       },
       "name": "8a. Is Client Request?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -2064,
         304
@@ -711,10 +736,15 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $json.error }}",
-              "operation": "isEmpty"
+              "leftValue": "={{ $json.error }}",
+              "operator": {
+                "type": "string",
+                "operation": "empty"
+              },
+              "rightValue": null
             }
           ]
         }
@@ -722,7 +752,7 @@
       "id": "c59de462-3c88-47f7-89b8-fea09a68a17c",
       "name": "8c. Dev Processor Failed?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -1312,
         288

--- a/n8n/flows/crm.proc.dev_request.json
+++ b/n8n/flows/crm.proc.dev_request.json
@@ -110,17 +110,22 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $('1a. Load Template').item.json.subject_template }}",
-              "operation": "isNotEmpty"
+              "leftValue": "={{ $('1a. Load Template').item.json.subject_template }}",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              },
+              "rightValue": null
             }
           ]
         }
       },
       "name": "1b. IF: Template Found?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -9712,
         272
@@ -424,10 +429,15 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $json.error }}",
-              "operation": "isEmpty"
+              "leftValue": "={{ $json.error }}",
+              "operator": {
+                "type": "string",
+                "operation": "empty"
+              },
+              "rightValue": null
             }
           ]
         }
@@ -435,7 +445,7 @@
       "id": "046a47e2-1f13-4bac-8c74-0f7d3aa987b5",
       "name": "4a. Initial Email Sent?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -7600,
         192

--- a/n8n/flows/hr.in.candidates.json
+++ b/n8n/flows/hr.in.candidates.json
@@ -20,17 +20,22 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $('1e. Validate & Shape').item.json.classification.label }}",
-              "value2": "spam"
+              "leftValue": "={{ $('1e. Validate & Shape').item.json.classification.label }}",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              },
+              "rightValue": "spam"
             }
           ]
         }
       },
       "name": "4. Is Spam?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -6464,
         176
@@ -219,17 +224,22 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $('1e. Validate & Shape').item.json.company_name }}",
-              "operation": "isNotEmpty"
+              "leftValue": "={{ $('1e. Validate & Shape').item.json.company_name }}",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              },
+              "rightValue": null
             }
           ]
         }
       },
       "name": "IF: Company Name Exists?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -6192,
         240
@@ -262,17 +272,22 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $('1e. Validate & Shape').item.json.company_website }}",
-              "operation": "isNotEmpty"
+              "leftValue": "={{ $('1e. Validate & Shape').item.json.company_website }}",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              },
+              "rightValue": null
             }
           ]
         }
       },
       "name": "IF: Website Exists?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -5872,
         96
@@ -347,17 +362,22 @@
     {
       "parameters": {
         "conditions": {
-          "number": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $('1. Find Contact by Email').item.json.contact_id }}",
-              "operation": "isNotEmpty"
+              "leftValue": "={{ $('1. Find Contact by Email').item.json.contact_id }}",
+              "operator": {
+                "type": "number",
+                "operation": "notEmpty"
+              },
+              "rightValue": null
             }
           ]
         }
       },
       "name": "2. IF: Contact Found?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -4752,
         336
@@ -648,24 +668,30 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "or",
+          "conditions": [
             {
-              "value1": "={{ $('1e. Validate & Shape').item.json.lead_intent }}",
-              "operation": "isEqual",
-              "value2": "candidate"
+              "leftValue": "={{ $('1e. Validate & Shape').item.json.lead_intent }}",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              },
+              "rightValue": "candidate"
             },
             {
-              "value1": "={{ $('1e. Validate & Shape').item.json.form_code }}",
-              "operation": "isEqual",
-              "value2": "vacancy"
+              "leftValue": "={{ $('1e. Validate & Shape').item.json.form_code }}",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              },
+              "rightValue": "vacancy"
             }
-          ],
-          "combineOperation": "any"
+          ]
         }
       },
       "name": "8a. Is Candidate Intent?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -2064,
         528
@@ -718,17 +744,22 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $json.error }}",
-              "operation": "isEmpty"
+              "leftValue": "={{ $json.error }}",
+              "operator": {
+                "type": "string",
+                "operation": "empty"
+              },
+              "rightValue": null
             }
           ]
         }
       },
       "name": "8b. Vacancy Processor Succeeded?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -1312,
         528

--- a/n8n/flows/hr.proc.vacancy.json
+++ b/n8n/flows/hr.proc.vacancy.json
@@ -121,7 +121,7 @@
         "operation": "executeQuery",
         "query": "INSERT INTO tasks (lead_id, type, due_at, notes)\\nSELECT $1, 'review_estimate', NOW() + interval '2 days', $2\\nWHERE NOT EXISTS (\\n  SELECT 1 FROM tasks WHERE lead_id = $1 AND type = 'review_estimate' AND status = 'open'\\n);\\n\\nINSERT INTO tasks (lead_id, type, due_at, notes)\\nSELECT $1, 'add_to_pool', NOW() + interval '7 days', $3\\nWHERE NOT EXISTS (\\n  SELECT 1 FROM tasks WHERE lead_id = $1 AND type = 'add_to_pool' AND status = 'open'\\n)\\nRETURNING id;",
         "options": {
-          "queryReplacement": "={{ [ $('0. Prepare Context').item.json.lead_id, '\u041f\u0440\u043e\u0432\u0435\u0440\u0438\u0442\u044c NDA \u0438 \u043f\u0440\u043e\u0444\u0438\u043b\u044c \u043a\u0430\u043d\u0434\u0438\u0434\u0430\u0442\u0430', '\u041f\u043e\u0434\u0433\u043e\u0442\u043e\u0432\u0438\u0442\u044c \u043a\u0430\u043d\u0434\u0438\u0434\u0430\u0442\u0430 \u043a \u0432\u043a\u043b\u044e\u0447\u0435\u043d\u0438\u044e \u0432 \u043f\u0443\u043b' ] }}"
+          "queryReplacement": "={{ [ $('0. Prepare Context').item.json.lead_id, 'Проверить NDA и профиль кандидата', 'Подготовить кандидата к включению в пул' ] }}"
         }
       },
       "name": "1c. Ensure Tasks",
@@ -186,7 +186,7 @@
     },
     {
       "parameters": {
-        "jsCode": "const ctx = $('0. Prepare Context').item.json;\nconst profile = ctx.candidate_profile || {};\nconst firstName = (ctx.full_name || '').split(' ')[0] || '\u041a\u043e\u043b\u043b\u0435\u0433\u0430';\nconst lang = ctx.preferred_lang || 'ru';\nconst availability = profile.availability || 'notice_period';\nconst skills = (profile.skills || []).slice(0, 3).join(', ');\nconst rate = profile.rate_min && profile.rate_currency ? `${profile.rate_min} ${profile.rate_currency}` : null;\nconst ndaUrl = ctx.nda_url;\n\nlet subject;\nlet body;\n\nif (lang === 'ru') {\n  subject = 'NDA \u0438 \u0441\u043b\u0435\u0434\u0443\u044e\u0449\u0438\u0439 \u0448\u0430\u0433 \u043f\u043e \u0441\u043e\u0442\u0440\u0443\u0434\u043d\u0438\u0447\u0435\u0441\u0442\u0432\u0443';\n  const lines = [];\n  lines.push(`\u041f\u0440\u0438\u0432\u0435\u0442, ${firstName}!`);\n  lines.push('\u0421\u043f\u0430\u0441\u0438\u0431\u043e \u0437\u0430 \u043e\u0442\u043a\u043b\u0438\u043a \u2014 \u043c\u044b \u043a\u0430\u043a \u0440\u0430\u0437 \u0441\u043e\u0431\u0438\u0440\u0430\u0435\u043c \u043f\u0443\u043b \u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442\u043e\u0432 \u043f\u043e\u0434 \u043f\u0440\u043e\u0435\u043a\u0442\u044b \u043a\u043b\u0438\u0435\u043d\u0442\u043e\u0432.');\n  lines.push(`\u0427\u0442\u043e\u0431\u044b \u043f\u043e\u0434\u0435\u043b\u0438\u0442\u044c\u0441\u044f \u0434\u0435\u0442\u0430\u043b\u044f\u043c\u0438, \u043f\u0440\u0438\u0448\u043b\u044e NDA: ${ndaUrl}`);\n  lines.push('\u041f\u043e\u0441\u043b\u0435 \u043f\u043e\u0434\u043f\u0438\u0441\u0438 \u043c\u043e\u0436\u0435\u043c \u043e\u0431\u0441\u0443\u0434\u0438\u0442\u044c \u0442\u0432\u043e\u0439 \u043e\u043f\u044b\u0442 \u0438 \u0431\u043b\u0438\u0436\u0430\u0439\u0448\u0438\u0435 \u0437\u0430\u0434\u0430\u0447\u0438.');\n  const extra = [];\n  if (skills) extra.push(`\u0421\u0442\u0435\u043a: ${skills}`);\n  if (rate) extra.push(`\u041e\u0440\u0438\u0435\u043d\u0442\u0438\u0440 \u043f\u043e \u0441\u0442\u0430\u0432\u043a\u0435: ${rate}`);\n  if (availability === 'available_now') {\n    extra.push('\u0414\u043e\u0441\u0442\u0443\u043f\u043d\u043e\u0441\u0442\u044c: \u0433\u043e\u0442\u043e\u0432 \u043f\u043e\u0434\u043a\u043b\u044e\u0447\u0438\u0442\u044c\u0441\u044f \u0441\u0440\u0430\u0437\u0443');\n  }\n  if (extra.length) {\n    lines.push(extra.join('\n'));\n  }\n  lines.push('\u0415\u0441\u043b\u0438 \u043f\u0443\u043b \u0438\u0434\u0435\u0430\u043b\u0435\u043d \u2014 \u043f\u043e\u0434\u0442\u0432\u0435\u0440\u0434\u0438\u043c \u0444\u043e\u0440\u043c\u0430\u0442 \u0438 \u0434\u043e\u0431\u0430\u0432\u0438\u043c \u0442\u0435\u0431\u044f \u0432 \u0431\u0430\u0437\u0443, \u0447\u0442\u043e\u0431\u044b \u043d\u0435 \u0442\u0435\u0440\u044f\u0442\u044c \u0432\u0440\u0435\u043c\u044f \u043d\u0430 \u0441\u0442\u0430\u0440\u0442\u0435 \u043f\u0440\u043e\u0435\u043a\u0442\u0430.');\n  lines.push('\u041d\u0430\u043f\u0438\u0448\u0438, \u043f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0443\u0434\u043e\u0431\u043d\u043e \u043b\u0438 \u043f\u043e\u0434\u043f\u0438\u0441\u0430\u0442\u044c NDA \u043d\u0430 \u044d\u0442\u043e\u0439 \u043d\u0435\u0434\u0435\u043b\u0435 \u0438 \u043a\u0430\u043a\u043e\u0439 \u0444\u043e\u0440\u043c\u0430\u0442 \u043e\u0431\u0449\u0435\u043d\u0438\u044f \u043f\u0440\u0435\u0434\u043f\u043e\u0447\u0438\u0442\u0430\u0435\u0448\u044c.');\n  body = lines.join('\n\n');\n} else {\n  subject = 'Next step & NDA for our talent pool';\n  const lines = [];\n  lines.push(`Hi ${firstName},`);\n  lines.push('Thanks for reaching out! We are building a vetted pool for upcoming client projects.');\n  lines.push(`Here is the NDA so we can share details: ${ndaUrl}`);\n  lines.push('Once it is signed we can jump on a short intro call and review current openings.');\n  const extra = [];\n  if (skills) extra.push(`Stack: ${skills}`);\n  if (rate) extra.push(`Rate expectation: ${rate}`);\n  if (availability === 'available_now') {\n    extra.push('Availability: ready to join immediately');\n  }\n  if (extra.length) {\n    lines.push(extra.join('\n'));\n  }\n  lines.push('Let me know if the NDA works for you and how you prefer to stay in touch.');\n  body = lines.join('\n\n');\n}\n\nreturn [{\n  subject,\n  body,\n  template_lang: lang\n}];"
+        "jsCode": "const ctx = $('0. Prepare Context').item.json;\nconst profile = ctx.candidate_profile || {};\nconst firstName = (ctx.full_name || '').split(' ')[0] || 'Коллега';\nconst lang = ctx.preferred_lang || 'ru';\nconst availability = profile.availability || 'notice_period';\nconst skills = (profile.skills || []).slice(0, 3).join(', ');\nconst rate = profile.rate_min && profile.rate_currency ? `${profile.rate_min} ${profile.rate_currency}` : null;\nconst ndaUrl = ctx.nda_url;\n\nlet subject;\nlet body;\n\nif (lang === 'ru') {\n  subject = 'NDA и следующий шаг по сотрудничеству';\n  const lines = [];\n  lines.push(`Привет, ${firstName}!`);\n  lines.push('Спасибо за отклик — мы как раз собираем пул специалистов под проекты клиентов.');\n  lines.push(`Чтобы поделиться деталями, пришлю NDA: ${ndaUrl}`);\n  lines.push('После подписи можем обсудить твой опыт и ближайшие задачи.');\n  const extra = [];\n  if (skills) extra.push(`Стек: ${skills}`);\n  if (rate) extra.push(`Ориентир по ставке: ${rate}`);\n  if (availability === 'available_now') {\n    extra.push('Доступность: готов подключиться сразу');\n  }\n  if (extra.length) {\n    lines.push(extra.join('\n'));\n  }\n  lines.push('Если пул идеален — подтвердим формат и добавим тебя в базу, чтобы не терять время на старте проекта.');\n  lines.push('Напиши, пожалуйста, удобно ли подписать NDA на этой неделе и какой формат общения предпочитаешь.');\n  body = lines.join('\n\n');\n} else {\n  subject = 'Next step & NDA for our talent pool';\n  const lines = [];\n  lines.push(`Hi ${firstName},`);\n  lines.push('Thanks for reaching out! We are building a vetted pool for upcoming client projects.');\n  lines.push(`Here is the NDA so we can share details: ${ndaUrl}`);\n  lines.push('Once it is signed we can jump on a short intro call and review current openings.');\n  const extra = [];\n  if (skills) extra.push(`Stack: ${skills}`);\n  if (rate) extra.push(`Rate expectation: ${rate}`);\n  if (availability === 'available_now') {\n    extra.push('Availability: ready to join immediately');\n  }\n  if (extra.length) {\n    lines.push(extra.join('\n'));\n  }\n  lines.push('Let me know if the NDA works for you and how you prefer to stay in touch.');\n  body = lines.join('\n\n');\n}\n\nreturn [{\n  subject,\n  body,\n  template_lang: lang\n}];"
       },
       "name": "3. Compose Initial Email",
       "type": "n8n-nodes-base.code",
@@ -332,18 +332,22 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ ($json.has_inbound_reply || $json.nda_signed) ? 'true' : 'false' }}",
-              "operation": "isEqual",
-              "value2": "true"
+              "leftValue": "={{ ($json.has_inbound_reply || $json.nda_signed) ? 'true' : 'false' }}",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              },
+              "rightValue": "true"
             }
           ]
         }
       },
       "name": "4b. Engaged After Initial?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -5760,
         0
@@ -352,7 +356,7 @@
     },
     {
       "parameters": {
-        "jsCode": "const ctx = $('0. Prepare Context').item.json;\nconst lang = ctx.preferred_lang || 'ru';\nconst firstName = (ctx.full_name || '').split(' ')[0] || '\u041a\u043e\u043b\u043b\u0435\u0433\u0430';\nconst ndaUrl = ctx.nda_url;\nlet subject;\nlet body;\nif (lang === 'ru') {\n  subject = '\u041f\u043e\u0434\u043f\u0438\u0441\u044c NDA \u0438 \u0441\u043b\u043e\u0442 \u0434\u043b\u044f \u0441\u043e\u0437\u0432\u043e\u043d\u0430';\n  body = [\n    `\u041f\u0440\u0438\u0432\u0435\u0442, ${firstName}!`,\n    '\u0414\u0443\u0431\u043b\u0438\u0440\u0443\u044e NDA, \u0447\u0442\u043e\u0431\u044b \u043c\u044b \u043c\u043e\u0433\u043b\u0438 \u043e\u0431\u0441\u0443\u0434\u0438\u0442\u044c \u043f\u0440\u043e\u0435\u043a\u0442\u044b \u0431\u0435\u0437 \u043e\u0433\u0440\u0430\u043d\u0438\u0447\u0435\u043d\u0438\u0439.',\n    ndaUrl,\n    '\u0415\u0441\u043b\u0438 \u0435\u0441\u0442\u044c \u0432\u043e\u043f\u0440\u043e\u0441\u044b \u043f\u043e \u0444\u043e\u0440\u043c\u0430\u0442\u0443 \u0438\u043b\u0438 \u0441\u0442\u0430\u0432\u043a\u0435 \u2014 \u043f\u0440\u043e\u0441\u0442\u043e \u043e\u0442\u0432\u0435\u0442\u044c \u043d\u0430 \u044d\u0442\u043e \u043f\u0438\u0441\u044c\u043c\u043e. \u041c\u043e\u0433\u0443 \u043f\u0440\u0435\u0434\u043b\u043e\u0436\u0438\u0442\u044c \u043d\u0435\u0441\u043a\u043e\u043b\u044c\u043a\u043e \u0441\u043b\u043e\u0442\u043e\u0432 \u043d\u0430 \u044d\u0442\u043e\u0439 \u043d\u0435\u0434\u0435\u043b\u0435.'\n  ].join('\n\n');\n} else {\n  subject = 'Gentle reminder about NDA';\n  body = [\n    `Hi ${firstName},`,\n    'Just following up on the NDA so we can move forward and review current opportunities.',\n    ndaUrl,\n    'Happy to jump on a short call \u2014 feel free to share a couple of time slots or any questions.'\n  ].join('\n\n');\n}\nreturn [{ subject, body, template_lang: lang }];"
+        "jsCode": "const ctx = $('0. Prepare Context').item.json;\nconst lang = ctx.preferred_lang || 'ru';\nconst firstName = (ctx.full_name || '').split(' ')[0] || 'Коллега';\nconst ndaUrl = ctx.nda_url;\nlet subject;\nlet body;\nif (lang === 'ru') {\n  subject = 'Подпись NDA и слот для созвона';\n  body = [\n    `Привет, ${firstName}!`,\n    'Дублирую NDA, чтобы мы могли обсудить проекты без ограничений.',\n    ndaUrl,\n    'Если есть вопросы по формату или ставке — просто ответь на это письмо. Могу предложить несколько слотов на этой неделе.'\n  ].join('\n\n');\n} else {\n  subject = 'Gentle reminder about NDA';\n  body = [\n    `Hi ${firstName},`,\n    'Just following up on the NDA so we can move forward and review current opportunities.',\n    ndaUrl,\n    'Happy to jump on a short call — feel free to share a couple of time slots or any questions.'\n  ].join('\n\n');\n}\nreturn [{ subject, body, template_lang: lang }];"
       },
       "name": "4c. Compose Follow-up #1",
       "type": "n8n-nodes-base.code",
@@ -475,18 +479,22 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ ($json.has_inbound_reply || $json.nda_signed) ? 'true' : 'false' }}",
-              "operation": "isEqual",
-              "value2": "true"
+              "leftValue": "={{ ($json.has_inbound_reply || $json.nda_signed) ? 'true' : 'false' }}",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              },
+              "rightValue": "true"
             }
           ]
         }
       },
       "name": "5b. Engaged After Follow-up #1?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -4080,
         0
@@ -495,7 +503,7 @@
     },
     {
       "parameters": {
-        "jsCode": "const ctx = $('0. Prepare Context').item.json;\nconst lang = ctx.preferred_lang || 'ru';\nconst firstName = (ctx.full_name || '').split(' ')[0] || '\u041a\u043e\u043b\u043b\u0435\u0433\u0430';\nlet subject;\nlet body;\nif (lang === 'ru') {\n  subject = '\u0414\u043e\u0431\u0430\u0432\u0438\u043c \u0432 \u043f\u0443\u043b \u0441\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442\u043e\u0432?';\n  body = [\n    `\u041f\u0440\u0438\u0432\u0435\u0442, ${firstName}!`,\n    '\u041f\u0438\u0448\u0443 \u0432 \u043f\u043e\u0441\u043b\u0435\u0434\u043d\u0438\u0439 \u0440\u0430\u0437 \u2014 \u043c\u044b \u0437\u0430\u0432\u0435\u0440\u0448\u0430\u0435\u043c \u043f\u043e\u0434\u0431\u043e\u0440 \u043f\u0443\u043b\u0430 \u043d\u0430 \u0431\u043b\u0438\u0436\u0430\u0439\u0448\u0438\u0435 \u043f\u0440\u043e\u0435\u043a\u0442\u044b.',\n    '\u0415\u0441\u043b\u0438 NDA \u0435\u0449\u0451 \u0432 \u043f\u0440\u043e\u0446\u0435\u0441\u0441\u0435 \u2014 \u043f\u0440\u0438\u0448\u043b\u044e \u043f\u043e\u0432\u0442\u043e\u0440\u043d\u043e, \u043f\u0440\u043e\u0441\u0442\u043e \u0434\u0430\u0439 \u0437\u043d\u0430\u0442\u044c. \u041f\u043e\u0441\u043b\u0435 \u043f\u043e\u0434\u043f\u0438\u0441\u0430\u043d\u0438\u044f \u0441\u043c\u043e\u0436\u0435\u043c \u0441\u0438\u043d\u0445\u0440\u043e\u043d\u0438\u0437\u0438\u0440\u043e\u0432\u0430\u0442\u044c \u0442\u0432\u043e\u0439 \u043f\u0440\u043e\u0444\u0438\u043b\u044c \u0441 \u0437\u0430\u043f\u0440\u043e\u0441\u0430\u043c\u0438 \u043a\u043b\u0438\u0435\u043d\u0442\u043e\u0432.',\n    '\u0415\u0441\u043b\u0438 \u0444\u043e\u0440\u043c\u0430\u0442 \u043d\u0435 \u043f\u043e\u0434\u0445\u043e\u0434\u0438\u0442 \u2014 \u0442\u043e\u0436\u0435 \u043e\u043a, \u0441\u043a\u0430\u0436\u0438, \u043f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0447\u0442\u043e\u0431\u044b \u044f \u043e\u0442\u043c\u0435\u0442\u0438\u043b \u0441\u0442\u0430\u0442\u0443\u0441.'\n  ].join('\n\n');\n} else {\n  subject = 'Final check-in for the talent pool';\n  body = [\n    `Hi ${firstName},`,\n    'We are wrapping up this hiring wave and I wanted to see if you still want to join the pool.',\n    'Happy to resend the NDA or jump on a quick call if needed.',\n    'If now is not the right time just let me know, so I can keep the status up to date.'\n  ].join('\n\n');\n}\nreturn [{ subject, body, template_lang: lang }];"
+        "jsCode": "const ctx = $('0. Prepare Context').item.json;\nconst lang = ctx.preferred_lang || 'ru';\nconst firstName = (ctx.full_name || '').split(' ')[0] || 'Коллега';\nlet subject;\nlet body;\nif (lang === 'ru') {\n  subject = 'Добавим в пул специалистов?';\n  body = [\n    `Привет, ${firstName}!`,\n    'Пишу в последний раз — мы завершаем подбор пула на ближайшие проекты.',\n    'Если NDA ещё в процессе — пришлю повторно, просто дай знать. После подписания сможем синхронизировать твой профиль с запросами клиентов.',\n    'Если формат не подходит — тоже ок, скажи, пожалуйста, чтобы я отметил статус.'\n  ].join('\n\n');\n} else {\n  subject = 'Final check-in for the talent pool';\n  body = [\n    `Hi ${firstName},`,\n    'We are wrapping up this hiring wave and I wanted to see if you still want to join the pool.',\n    'Happy to resend the NDA or jump on a quick call if needed.',\n    'If now is not the right time just let me know, so I can keep the status up to date.'\n  ].join('\n\n');\n}\nreturn [{ subject, body, template_lang: lang }];"
       },
       "name": "5c. Compose Follow-up #2",
       "type": "n8n-nodes-base.code",
@@ -618,18 +626,22 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ ($json.has_inbound_reply || $json.nda_signed) ? 'true' : 'false' }}",
-              "operation": "isEqual",
-              "value2": "true"
+              "leftValue": "={{ ($json.has_inbound_reply || $json.nda_signed) ? 'true' : 'false' }}",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              },
+              "rightValue": "true"
             }
           ]
         }
       },
       "name": "6b. Engaged After Follow-up #2?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -2400,
         0

--- a/n8n/flows/ops.in.calendly.json
+++ b/n8n/flows/ops.in.calendly.json
@@ -40,17 +40,22 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $('1. Validate & Parse').item.json.event_type }}",
-              "value2": "invitee.created"
+              "leftValue": "={{ $('1. Validate & Parse').item.json.event_type }}",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              },
+              "rightValue": "invitee.created"
             }
           ]
         }
       },
       "name": "3. IF: Event Type?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -1152,
         -176
@@ -224,17 +229,22 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $('2. Find Lead by Email').item.json.lead_id }}",
-              "operation": "isNotEmpty"
+              "leftValue": "={{ $('2. Find Lead by Email').item.json.lead_id }}",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              },
+              "rightValue": null
             }
           ]
         }
       },
       "name": "3. IF: Lead exist",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
+      "typeVersion": 2.2,
       "position": [
         -1408,
         -176

--- a/n8n/flows/sub.mkt.send_sequence_step.json
+++ b/n8n/flows/sub.mkt.send_sequence_step.json
@@ -5,7 +5,10 @@
       "name": "[START] Sub-workflow Trigger",
       "type": "n8n-nodes-base.executeWorkflowTrigger",
       "typeVersion": 1,
-      "position": [-656, 352],
+      "position": [
+        -656,
+        352
+      ],
       "id": "3d5c498d-bf50-4576-942e-655c9dcceb34"
     },
     {
@@ -80,7 +83,10 @@
       "name": "0. Ctx & Config",
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
-      "position": [-448, 352],
+      "position": [
+        -448,
+        352
+      ],
       "id": "8de1e8bc-a5cf-4b72-b619-396713c267d2"
     },
     {
@@ -94,7 +100,10 @@
       "name": "1a. Load Template",
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
-      "position": [-240, 352],
+      "position": [
+        -240,
+        352
+      ],
       "id": "2245b890-626a-460f-8db5-dcca3b6e652c",
       "alwaysOutputData": true,
       "credentials": {
@@ -107,18 +116,26 @@
     {
       "parameters": {
         "conditions": {
-          "string": [
+          "combinator": "and",
+          "conditions": [
             {
-              "value1": "={{ $('1a. Load Template').item.json.subject_template }}",
-              "operation": "isNotEmpty"
+              "leftValue": "={{ $('1a. Load Template').item.json.subject_template }}",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              },
+              "rightValue": null
             }
           ]
         }
       },
       "name": "1b. IF: Template Found?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 1,
-      "position": [-48, 352],
+      "typeVersion": 2.2,
+      "position": [
+        -48,
+        352
+      ],
       "id": "7348b6a7-f04e-499f-a54e-5621779afac2"
     },
     {
@@ -132,7 +149,10 @@
       "name": "1c-fallback. Load Fallback",
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
-      "position": [224, 464],
+      "position": [
+        224,
+        464
+      ],
       "id": "aaee2c2e-b589-406a-aab0-abf386846cce",
       "credentials": {
         "postgres": {
@@ -164,7 +184,10 @@
       "name": "1d-prep. Prepare AI Prompt Vars",
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
-      "position": [432, 464],
+      "position": [
+        432,
+        464
+      ],
       "id": "2208a1d5-73ab-4450-8ddd-d4025ae6d830"
     },
     {
@@ -191,7 +214,10 @@
       "name": "1d-translate. AI Translate Template",
       "type": "@n8n/n8n-nodes-langchain.anthropic",
       "typeVersion": 1,
-      "position": [640, 464],
+      "position": [
+        640,
+        464
+      ],
       "id": "6ea2ee71-2d29-4d49-892e-2ba45d2b144e",
       "retryOnFail": true,
       "waitBetweenTries": 5000,
@@ -208,7 +234,10 @@
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [976, 464],
+      "position": [
+        976,
+        464
+      ],
       "name": "1e. Parse AI JSON",
       "id": "8b94fa7c-6bbd-42c6-b268-37d8289bbc92"
     },
@@ -235,7 +264,10 @@
       "name": "1f. Shape 'True' Path Data",
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
-      "position": [224, 256],
+      "position": [
+        224,
+        256
+      ],
       "id": "83d339a1-c34c-4eeb-8d3e-8bd5fa17bb77"
     },
     {
@@ -249,7 +281,10 @@
       "name": "2. Merge Template Branches",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3.2,
-      "position": [1216, 272],
+      "position": [
+        1216,
+        272
+      ],
       "id": "2a09e3f0-b967-4658-a69e-b6a1896f48dc"
     },
     {
@@ -259,7 +294,10 @@
       "name": "2b. Compose Reply",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1440, 272],
+      "position": [
+        1440,
+        272
+      ],
       "id": "89882a14-0aa0-44be-8c16-ef50063f4570"
     },
     {
@@ -268,7 +306,10 @@
       },
       "type": "n8n-nodes-base.wait",
       "typeVersion": 1.1,
-      "position": [1648, 272],
+      "position": [
+        1648,
+        272
+      ],
       "id": "ee0c4214-1940-4eef-9362-15dc394751b7",
       "name": "Wait",
       "webhookId": "0ed5fff5-199e-4b43-aaa1-efaddd42c30a"
@@ -284,7 +325,10 @@
       },
       "type": "n8n-nodes-base.gmail",
       "typeVersion": 2.1,
-      "position": [1856, 272],
+      "position": [
+        1856,
+        272
+      ],
       "id": "9e3a57ec-dd4c-47a5-b868-7fd43d1b8050",
       "name": "3. Send a message",
       "webhookId": "8396ef9f-dbc4-4313-87c9-62f41f0fd358",
@@ -306,7 +350,10 @@
       "name": "4b. Log Outbound Message",
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
-      "position": [2064, 272],
+      "position": [
+        2064,
+        272
+      ],
       "id": "fd5fa3af-b0ee-4243-a927-9f3af9d82e8f",
       "credentials": {
         "postgres": {
@@ -326,7 +373,10 @@
       "name": "4c. Add Tag to Lead",
       "type": "n8n-nodes-base.postgres",
       "typeVersion": 2.6,
-      "position": [2272, 272],
+      "position": [
+        2272,
+        272
+      ],
       "id": "b2cbb76e-1242-443a-b363-e76cc69dc3cb",
       "credentials": {
         "postgres": {


### PR DESCRIPTION
## Summary
- migrate IF nodes in CRM, HR, ops, and marketing workflows to the new filter syntax with combinators and explicit operators
- require the updated IF node syntax in the contributor checklist

## Testing
- pnpm flows:validate *(fails: No package.json in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d66a4ca7748332a30863776f744a6a